### PR TITLE
Fix fatal error on default errors without exceptions

### DIFF
--- a/src/ZendSentry/Mvc/View/Http/ExceptionStrategy.php
+++ b/src/ZendSentry/Mvc/View/Http/ExceptionStrategy.php
@@ -136,9 +136,6 @@ class ExceptionStrategy implements ListenerAggregateInterface
             return;
         }
 
-        // Log exception to sentry by triggering an exception event
-        $e->getApplication()->getEventManager()->trigger('logException', $this, array('exception' => $e->getParam('exception')));
-
         // Proceed to showing an error page with or without exception
         switch ($error) {
             case Application::ERROR_CONTROLLER_NOT_FOUND:
@@ -149,6 +146,9 @@ class ExceptionStrategy implements ListenerAggregateInterface
 
             case Application::ERROR_EXCEPTION:
             default:
+                // Log exception to sentry by triggering an exception event
+                $e->getApplication()->getEventManager()->trigger('logException', $this, array('exception' => $e->getParam('exception')));
+
                 $model = new ViewModel(array(
                     'message'            => 'Oh no. Something went wrong, but we have been notified.',
                     'exception'          => $e->getParam('exception'),


### PR DESCRIPTION
There is fatal error when logging some default errors which are not exceptions. For example:

``` php
case Application::ERROR_CONTROLLER_NOT_FOUND:
case Application::ERROR_CONTROLLER_INVALID:
case Application::ERROR_ROUTER_NO_MATCH:
```
