### PR TITLE
It fixed a bug with set an error reporting level

### DIFF
--- a/Module.php
+++ b/Module.php
@@ -102,7 +102,12 @@ class Module
 
         // If ZendSentry is configured to log errors, register it as error handler
         if ($this->config['zend-sentry']['handle-errors']) {
-            $this->zendSentry->registerErrorHandler($this->config['zend-sentry']['call-existing-error-handler']);
+            $this->zendSentry->registerErrorHandler(
+                $this->config['zend-sentry']['call-existing-error-handler'],
+                array_key_exists('error-reporting', $this->config['zend-sentry'])
+                    ? $this->config['zend-sentry']['error-reporting']
+                    : -1
+            );
         }
 
         // If ZendSentry is configured to log shutdown errors, register it

--- a/Module.php
+++ b/Module.php
@@ -19,6 +19,7 @@ use ZendSentry\Mvc\View\Console\ExceptionStrategy as SentryConsoleStrategy;
 use Zend\Mvc\View\Http\ExceptionStrategy;
 use Raven_Client as Raven;
 use Zend\Log\Logger;
+use Zend\Console\Console;
 
 /**
  * Class Module
@@ -190,7 +191,7 @@ class Module
         $exceptionStrategy->detach($this->eventManager);
 
         // Check if script is running in console
-        $exceptionStrategy = (PHP_SAPI == 'cli') ? (new SentryConsoleStrategy()) : (new SentryHttpStrategy());
+        $exceptionStrategy = Console::isConsole() ? (new SentryConsoleStrategy()) : (new SentryHttpStrategy());
         $exceptionStrategy->attach($this->eventManager);
         $exceptionStrategy->setDisplayExceptions($this->config['zend-sentry']['display-exceptions']);
         $exceptionStrategy->setDefaultExceptionMessage($this->config['zend-sentry'][(PHP_SAPI == 'cli') ? 'default-exception-console-message' : 'default-exception-message']);

--- a/Module.php
+++ b/Module.php
@@ -80,7 +80,11 @@ class Module
         }
 
         $sentryApiKey = $this->config['zend-sentry']['sentry-api-key'];
-        $ravenClient = new Raven($sentryApiKey, $ravenConfig);
+        $ravenClass = 'Raven';
+        if (array_key_exists('raven-client', $this->config['zend-sentry'])) {
+            $ravenClass = $this->config['zend-sentry']['raven-client'];
+        }
+        $ravenClient = new $ravenClass($sentryApiKey, $ravenConfig);
 
         // Register the RavenClient as a application wide service
         $event->getApplication()->getServiceManager()->setService('raven', $ravenClient);

--- a/README.md
+++ b/README.md
@@ -4,12 +4,13 @@ Scrutizier analysis: [![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/c
 
 ZendSentry is released under the New BSD License.
 
-The current version of ZendSentry is `1.5.1`.
+The current version of ZendSentry is `1.6.0`.
 
 #Latest Changes
 - [BnitoBzh](https://github.com/BnitoBzh) made screen and cli error messages configurable.
 
 #Important Changes
+- 1.6.0: added a custom sentry client
 - 1.4.0: Raven configuration can now be overwritten through ZendSentry configuration if needed
 - 1.3.0: updated raven dependency to latest (0.10.0), important security relevant changes (curl), upgrade is strongly recommended
 - 1.2.0: supports tags, every logging action returns the Sentry event_id, Raven is registered as Service

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "keywords": ["log", "logging", "sentry", "raven", "zend-framework"],
     "homepage": "https://github.com/cloud-solutions/zend-sentry",
     "type": "library",
-    "version": "1.5.2",
+    "version": "1.6.0",
     "license": "New BSD License",
     "authors": [
         {

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "keywords": ["log", "logging", "sentry", "raven", "zend-framework"],
     "homepage": "https://github.com/cloud-solutions/zend-sentry",
     "type": "library",
-    "version": "1.5.1",
+    "version": "1.5.2",
     "license": "New BSD License",
     "authors": [
         {

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "keywords": ["log", "logging", "sentry", "raven", "zend-framework"],
     "homepage": "https://github.com/cloud-solutions/zend-sentry",
     "type": "library",
-    "version": "1.6.0",
+    "version": "1.6.1",
     "license": "New BSD License",
     "authors": [
         {

--- a/config/zend-sentry.global.php.dist
+++ b/config/zend-sentry.global.php.dist
@@ -62,10 +62,16 @@ $settings = array(
     'handle-javascript-errors' => true,
 
     /**
+     * The error reporting level that will be send to sentry
+     */
+    'error-reporting' => -1,
+
+    /**
      * Set raven config options here.
      * Raven has sensible defaults set in Raven_Client, if you need to override them, this is where you can do it.
      */
     'raven-config' => array(),
+
 );
 
 /**


### PR DESCRIPTION
The bootstrap was the bug when do registerErrorHandler(), because the Raven_ErrorHandler::registerErrorHandler() expect an error reporting level for second argument