### PR TITLE
Docblock comment return type change on Sentry::doWrite()

### DIFF
--- a/src/ZendSentry/Log/Writer/Sentry.php
+++ b/src/ZendSentry/Log/Writer/Sentry.php
@@ -46,7 +46,7 @@ class Sentry extends AbstractWriter
      * Write a message to the log
      *
      * @param array $event log data event
-     * @return void
+     * @return string $eventID the event ID
      */
     protected function doWrite(array $event)
     {


### PR DESCRIPTION
Existing @return type was documented as void - changed to be a string which is the Sentry event ID