### PR TITLE
handle errors without exceptions

### DIFF
--- a/src/ZendSentry/Mvc/View/Http/ExceptionStrategy.php
+++ b/src/ZendSentry/Mvc/View/Http/ExceptionStrategy.php
@@ -162,6 +162,13 @@ class ExceptionStrategy implements ListenerAggregateInterface
 
             case Application::ERROR_EXCEPTION:
             default:
+                // check if there really is an exception
+                // zf2 also throw normal errors, for example: error-route-unauthorized
+                // if there is no exception we have nothing to log
+                if ($e->getParam('exception') == null) {
+                    return;
+                }
+
                 // Log exception to sentry by triggering an exception event
                 $eventID = $e->getApplication()->getEventManager()->trigger('logException', $this, array('exception' => $e->getParam('exception')));
 


### PR DESCRIPTION
ZF2 also throws normal framework errors which may NOT have an exception embedded. Therefore we need to check if there really is an exception to log within the parameters.