### PR TITLE
Create tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+vendor
+composer.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,10 @@
 language: php
+sudo: false
 
 jobs:
   include:
   - stage: Unit tests
-  - env:
-    php: 5.6
-  - env: COMPOSER_FLAGS="--prefer-lowest"
-    php: 5.6
-  - env:
+    env:
     php: 7.0
   - env: COMPOSER_FLAGS="--prefer-lowest"
     php: 7.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,27 +1,27 @@
 language: php
 
-matrix:
-  fast_finish: true
+jobs:
   include:
-  - env: TEST_DIR=.
+  - stage: Unit tests
+  - env:
     php: 5.6
-  - env: TEST_DIR=. COMPOSER_FLAGS="--prefer-lowest"
+  - env: COMPOSER_FLAGS="--prefer-lowest"
     php: 5.6
-  - env: TEST_DIR=.
+  - env:
     php: 7.0
-  - env: TEST_DIR=. COMPOSER_FLAGS="--prefer-lowest"
+  - env: COMPOSER_FLAGS="--prefer-lowest"
     php: 7.0
-  - env: TEST_DIR=.
+  - env:
     php: 7.1
-  - env: TEST_DIR=. COMPOSER_FLAGS="--prefer-lowest"
+  - env: COMPOSER_FLAGS="--prefer-lowest"
     php: 7.1
-  - env: TEST_DIR=.
+  - env:
     php: 7.2
-  - env: TEST_DIR=. COMPOSER_FLAGS="--prefer-lowest"
+  - env: COMPOSER_FLAGS="--prefer-lowest"
     php: 7.2
-  - env: TEST_DIR=.
+  - env:
     php: 7.3
-  - env: TEST_DIR=. COMPOSER_FLAGS="--prefer-lowest"
+  - env: COMPOSER_FLAGS="--prefer-lowest"
     php: 7.3
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,39 @@
+language: php
+
+matrix:
+  fast_finish: true
+  include:
+  - env: TEST_DIR=.
+    php: 5.6
+  - env: TEST_DIR=. COMPOSER_FLAGS="--prefer-lowest"
+    php: 5.6
+  - env: TEST_DIR=.
+    php: 7.0
+  - env: TEST_DIR=. COMPOSER_FLAGS="--prefer-lowest"
+    php: 7.0
+  - env: TEST_DIR=.
+    php: 7.1
+  - env: TEST_DIR=. COMPOSER_FLAGS="--prefer-lowest"
+    php: 7.1
+  - env: TEST_DIR=.
+    php: 7.2
+  - env: TEST_DIR=. COMPOSER_FLAGS="--prefer-lowest"
+    php: 7.2
+  - env: TEST_DIR=.
+    php: 7.3
+  - env: TEST_DIR=. COMPOSER_FLAGS="--prefer-lowest"
+    php: 7.3
+
+before_install:
+- composer self-update
+
+install:
+- composer update -o $COMPOSER_FLAGS
+
+script:
+- ./vendor/bin/phpunit
+
+cache:
+  directories:
+  - vendor
+  - $HOME/.composer/cache

--- a/composer.json
+++ b/composer.json
@@ -19,12 +19,16 @@
         "zendframework/zend-mvc": "^2.5 || ^3.0",
         "zendframework/zend-log": "^2.5 || ^3.0"
     },
+    "require-dev": {
+        "phpunit/phpunit": "^5.7.27 || ^6.5.8 || ^7.1.5"
+    },
     "conflict": {
         "zendframework/zendframework": "<3.0.0"
     },
     "autoload": {
         "psr-0": {
-            "ZendSentry": "src/"
+            "ZendSentry": "src/",
+            "ZendSentryTests": "tests/"
         },
         "classmap": [
             "./Module.php"

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,10 @@
     ],
     "require": {
         "php": "^5.6 || ^7.0",
-        "sentry/sentry": "^1.9.2"
+        "sentry/sentry": "^1.9.2",
+        "zendframework/zend-eventmanager": "^2.5|| ^3.0",
+        "zendframework/zend-mvc": "^2.5 || ^3.0",
+        "zendframework/zend-log": "^2.5 || ^3.0"
     },
     "conflict": {
         "zendframework/zendframework": "<3.0.0"

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         }
     ],
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": ">=7.0",
         "sentry/sentry": "^1.9.2",
         "zendframework/zend-eventmanager": "^2.5|| ^3.0",
         "zendframework/zend-mvc": "^2.5 || ^3.0",

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,26 @@
+<phpunit bootstrap="./tests/bootstrap.php"
+         colors="true"
+         convertErrorsToExceptions="true"
+         convertNoticesToExceptions="true"
+         convertWarningsToExceptions="true"
+         verbose="true"
+         stopOnFailure="false"
+         processIsolation="false"
+>
+    <testsuite name="Zend Sentry test suite">
+        <directory>./tests/ZendSentryTest</directory>
+    </testsuite>
+
+
+    <filter>
+        <whitelist>
+            <directory suffix=".php">./src</directory>
+            <file>./../Module.php</file>
+        </whitelist>
+    </filter>
+
+    <logging>
+        <log type="coverage-text" target="php://stdout"/>
+        <log type="coverage-clover" target="../build/logs/clover.xml"/>
+    </logging>
+</phpunit>

--- a/tests/ZendSentryTest/ModuleTest.php
+++ b/tests/ZendSentryTest/ModuleTest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace ZendSentryTest;
+
+use PHPUnit\Framework\TestCase;
+use Zend\Loader\StandardAutoloader;
+use ZendSentry\Module as ZendSentryModule;
+
+class ModuleTest extends TestCase
+{
+    /**
+     * @var ZendSentryModule
+     */
+    private $module;
+
+    public function setUp()
+    {
+        parent::setUp();
+        $this->module = new ZendSentryModule();
+    }
+
+    public function testDefaultModuleConfig()
+    {
+        $expectedConfig = [];
+
+        $actualConfig = $this->module->getConfig();
+
+        $this->assertEquals($expectedConfig, $actualConfig);
+    }
+
+    public function testAutoloaderConfig()
+    {
+        $expectedConfig = [
+            StandardAutoloader::class => [
+                'namespaces' => [
+                    'ZendSentry' => realpath(__DIR__. '/../../src/ZendSentry')
+                ]
+            ]
+        ];
+
+        $actualConfig = $this->module->getAutoloaderConfig();
+
+        $this->assertEquals($expectedConfig, $actualConfig);
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,18 @@
+<?php
+
+chdir(__DIR__);
+
+$loader = null;
+if (file_exists('../vendor/autoload.php')) {
+    $loader = include '../vendor/autoload.php';
+} elseif (file_exists('../../../autoload.php')) {
+    $loader = include '../../../autoload.php';
+} else {
+    throw new RuntimeException('vendor/autoload.php could not be found. Did you run `php composer.phar install`?');
+}
+
+$loader->add('ZendSentryTest', __DIR__);
+
+if (!$config = @include 'configuration.php') {
+    $config = require 'configuration.php.dist';
+}

--- a/tests/configuration.php.dist
+++ b/tests/configuration.php.dist
@@ -1,0 +1,2 @@
+<?php
+return array();


### PR DESCRIPTION
Hi there :wave: 

This is an start for #10 allowing you to run test in a CI environment like Travis. There is a successful build of this branch right [here](https://travis-ci.com/nstapelbroek/zend-sentry/builds/88599183). 

I had to change a couple of things to get this done. Details below.

### What has been done
- Dropped support for PHP 5.6 since you were already using the return types
- Listed the Zend Framework dependencies used in composer.json so you can develop and test this module without integrating it in a complete ZF application. 
- Created a Travis build matrix/pipeline that will test the module across all PHP 7 versions
- Created two tests who assert the default config, so no actual behavioral tests

### How to test
- Checkout PR
- Run composer update 
- Acknowledge that PHPunit is installed
- Run `./vendor/bin/phpunit` and acknowledge that the tests run
